### PR TITLE
chore(separated_queries): Generates separated query for each object

### DIFF
--- a/src/schema/GraphqlSchemaGenerator.js
+++ b/src/schema/GraphqlSchemaGenerator.js
@@ -64,7 +64,7 @@ class GraphqlSchemaGenerator {
       let bdmAtts = bdmBusObject.fields.field;
       if (bdmAtts) {
         myself._generateAttributeQueries(queries, bdmObjectName, myself._asArray(bdmAtts));
-        queries.push('\t', 'findBy: ', bdmObjectName, '\n');
+        queries.push('\t', 'find: ', bdmObjectName, '\n');
       }
       // Generate default queries from unique constraints
       let constraints = bdmBusObject.uniqueConstraints.uniqueConstraint;

--- a/src/schema/GraphqlSchemaGenerator.js
+++ b/src/schema/GraphqlSchemaGenerator.js
@@ -92,9 +92,6 @@ class GraphqlSchemaGenerator {
     // This is the (mandatory) Query root.
     // Note: not used for now. Could be one of the current xxxQuery (?)
     this.schema.push('type Query ', '{\n', '\t', 'content: String', '\n', '}\n\n');
-    let schemaStr = this.schema.join('');
-    console.log(schemaStr);
-    console.log('END SCHEMA');
   }
 
   getResolvers() {


### PR DESCRIPTION
- We now get a dedicated Query for each object 
e.g. :
type CustomerQuery {
	findByName(name: String!): Customer
	findByAddress(address: String!): Customer
	findByPhoneNumber(phoneNumber: String!): Customer
	findBy: Customer
	findByNameAndPhoneNumber(name: String!, phoneNumber: String!): Customer
	findByAddressAndPhoneNumberAndName(address: String!, phoneNumber: String!, name: String!): Customer
}
