### PR TITLE
fix(multiple_parameter) : handle correctly collections for Attribute and Query parameter

### DIFF
--- a/src/schema/GraphqlSchemaGenerator.ts
+++ b/src/schema/GraphqlSchemaGenerator.ts
@@ -114,6 +114,7 @@ export class GraphqlSchemaGenerator {
   }
 
   public getSchema() {
+    // console.log(this.schema.join(''));
     return this.schema.join('');
   }
 
@@ -125,6 +126,9 @@ export class GraphqlSchemaGenerator {
     for (let bdmAtt of bdmAttsArray) {
       let mandatoryStr = bdmAtt._attributes.nullable === 'true' ? '' : '!';
       let type = GraphqlSchemaGenerator.xmlToGraphqlType(bdmAtt._attributes.type);
+      if (bdmAtt._attributes.collection === 'true') {
+        type = '[' + type + ']';
+      }
       let name = bdmAtt._attributes.name;
       this.schema.push('\t', name, ': ', type + mandatoryStr, '\n');
       attributesTypeMap.set(name, type);
@@ -326,10 +330,13 @@ export class GraphqlSchemaGenerator {
     for (let parameter of parametersArray) {
       let paramName = parameter._attributes.name;
       let paramType = parameter._attributes.className;
-      paramsMap.set(
-        paramName,
-        GraphqlSchemaGenerator.xmlToGraphqlType(GraphqlSchemaGenerator.getLastItem(paramType))
-      );
+      let type = GraphqlSchemaGenerator.getLastItem(paramType);
+      if (type.endsWith(';')) {
+        // this is a type of xml form '[Ljava.lang.String;', so an array
+        // Here, the last item is something like 'String;' => [String] in GraphQL
+        type = '[' + type.substring(0, type.length - 1) + ']';
+      }
+      paramsMap.set(paramName, GraphqlSchemaGenerator.xmlToGraphqlType(type));
     }
     let paramsStringArray: string[] = [];
     paramsMap.forEach((value, key) => {

--- a/test/GraphqlSchemaGenerator.test.ts
+++ b/test/GraphqlSchemaGenerator.test.ts
@@ -24,11 +24,23 @@ describe('GraphqlSchemaGenerator', () => {
     expect(schema).toContain('type com_company_model_OrderInfoQuery');
   });
 
+  test('Check expected attributes in graphQL schema', () => {
+    let schema = _getSchema('test/resources/bdm_CustomerOrder.xml');
+    expect(schema).toContain(
+      'type com_company_model_Customer {\n' +
+        '\tname: String\n' +
+        '\taddress: [String]\n' +
+        '\tphoneNumber: String\n' +
+        '\tcomment: [String]\n' +
+        '\torders: com_company_model_OrderInfo\n' +
+        '}'
+    );
+  });
+
   test('Check expected queries from attributes in graphQL schema', () => {
     let schema = _getSchema('test/resources/bdm_CustomerOrder.xml');
     expect(schema).toContain('type com_company_model_CustomerAttributeQuery');
     expect(schema).toContain('findByName(name: String!): com_company_model_Customer');
-    expect(schema).toContain('findByAddress(address: String!): com_company_model_Customer');
     expect(schema).toContain('findByPhoneNumber(phoneNumber: String!): com_company_model_Customer');
     expect(schema).not.toContain('findByComment');
     expect(schema).toContain('find: com_company_model_Customer');
@@ -46,7 +58,7 @@ describe('GraphqlSchemaGenerator', () => {
       'findByNameAndPhoneNumber(name: String!, phoneNumber: String!): com_company_model_Customer'
     );
     expect(schema).toContain(
-      'findByAddressAndPhoneNumberAndName(address: String!, phoneNumber: String!, name: String!): com_company_model_Customer'
+      'findByAddressAndPhoneNumberAndName(address: [String]!, phoneNumber: String!, name: String!): com_company_model_Customer'
     );
   });
 
@@ -54,7 +66,7 @@ describe('GraphqlSchemaGenerator', () => {
     let schema = _getSchema('test/resources/bdm_CustomerOrder.xml');
     expect(schema).toContain('type com_company_model_CustomerCustomQuery');
     expect(schema).toContain(
-      'query1(name: String!, address: String!, phoneNumber: String!): [com_company_model_Customer]'
+      'query1(name: String!, address: [String]!, phoneNumber: String!): [com_company_model_Customer]'
     );
     expect(schema).toContain('query2(name: String!, address: String!): com_company_model_Customer');
     expect(schema).toContain('query3: Int');

--- a/test/resources/bdm_CustomerOrder.xml
+++ b/test/resources/bdm_CustomerOrder.xml
@@ -4,7 +4,7 @@
         <businessObject qualifiedName="com.company.model.Customer">
             <fields>
                 <field type="STRING" length="255" name="name" nullable="true" collection="false"/>
-                <field type="STRING" length="255" name="address" nullable="true" collection="false"/>
+                <field type="STRING" length="255" name="address" nullable="true" collection="true"/>
                 <field type="STRING" length="255" name="phoneNumber" nullable="true" collection="false"/>
                 <field type="STRING" length="255" name="comment" nullable="true" collection="true"/>
                 <relationField type="AGGREGATION" reference="com.company.model.OrderInfo" fetchType="LAZY" name="orders" nullable="true" collection="true"/>
@@ -28,7 +28,7 @@
                 <query name="query1" content="SELECT c &#xA;FROM Customer c &#xA;WHERE c.name = :name&#xA;AND c.address = :address&#xA;AND c.phoneNumber = :phoneNumber&#xA;ORDER BY c.persistenceId ASC" returnType="java.util.List">
                     <queryParameters>
                         <queryParameter name="name" className="java.lang.String"/>
-                        <queryParameter name="address" className="java.lang.String"/>
+                        <queryParameter name="address" className="[Ljava.lang.String;"/>
                         <queryParameter name="phoneNumber" className="java.lang.String"/>
                     </queryParameters>
                 </query>


### PR DESCRIPTION
GraphQL schema is now correctly generated for:
- Attribute set as 'multiple'
- Query parameter type is an array (e.g. java.lang.String[] )

Covers[UID-252](https://bonitasoft.atlassian.net/browse/UID-252)