### PR TITLE
chore(devEnv) move health check configuration to dev to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Start the server with a BDM:
 ```
 $ node target/src/server/starter.js bdmFile=YOUR_PATH/bdm_simple.xml
 or
-$ npm run start bdmFile=YOUR_PATH/bdm_simple.xml
+$ npm run start
 ```
 
 ### Options
@@ -37,7 +37,7 @@ $ npm run start bdmFile=YOUR_PATH/bdm_simple.xml
 
 Each option can be given on server start command. Config parameter will be always override file configuration.
 
-Example of config file:
+Example of dev config file:
 
 ```
 {
@@ -47,6 +47,8 @@ Example of config file:
   "logfile": "./logs"
 }
 ```
+
+To simulate 'production' environment, don't forget to add healthCheck information. You can see an example in config/production.json file.
 
 ## Connect to GraphiQL
 

--- a/config/development.json
+++ b/config/development.json
@@ -1,9 +1,6 @@
 {
   "port": "4000",
-  "bdmFile": "resources/bomBBVA.xml",
+  "bdmFile": "resources/bdm_simple.xml",
   "logLevel": "debug",
-  "logfile": "./logs",
-  "healthCheckPort": 54896,
-  "healthCheckUrl": "/api/workspace/status/",
-  "healthCheckHost": "http://localhost"
+  "logfile": "./logs"
 }

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,9 @@
 {
   "port": "4000",
-  "bdmFile": "resources/bomAG2R.xml",
+  "bdmFile": "resources/bdm_simple.xml",
   "logFile": "target/log/data-repository.log",
-  "logLevel": "debug"
+  "logLevel": "debug",
+  "healthCheckPort": 54896,
+  "healthCheckUrl": "/api/workspace/status/",
+  "healthCheckHost": "http://localhost"
 }


### PR DESCRIPTION
* When we work on local (without health check) we don't want kill our process
* Adding data in Readme