### PR TITLE
 chore(doc): skip commit when generate dep is empty

### DIFF
--- a/infrastructure/dependencies/dependencies.sh
+++ b/infrastructure/dependencies/dependencies.sh
@@ -94,9 +94,13 @@ FOLDER=${BASEDIR}/${SOURCE_FOLDER}
 node ../${SCRIPT_DIR}/node_modules/@bonitasoft/dependency-list-to-markdown/src/generateMarkdownContent.js --folder=${FOLDER} --outputFile ${OUTPUT_FILE} --header="Bonita Data-repository dependencies ${VERSION}" --description="List all dependencies uses for Bonita Data-repository" --frontend
 
 #Commit & Push
-git add ${OUTPUT_FILE}
-git commit -m "${COMMIT_MESSAGE}"
-git push origin ${BRANCH}
+if [ -z "$(git status --porcelain)" ]; then
+  echo "No changes in dependencies, nothing to commit."
+else
+  git add ${OUTPUT_FILE}
+  git commit -m "${COMMIT_MESSAGE}"
+  git push origin ${BRANCH}
+fi
 
 popd
 


### PR DESCRIPTION
When the generate dependencies script does not change the file, the job was
 failing because there was nothing to commit.

Simply check if the working dir is clean or not before commiting.
The create PR does nothing but do not fails in that case

Relates to [CI-629](https://bonitasoft.atlassian.net/browse/CI-629)