### PR TITLE
fix(proxy): configure no_proxy settings for localhost

### DIFF
--- a/src/StudioHealthCheck.ts
+++ b/src/StudioHealthCheck.ts
@@ -57,6 +57,9 @@ export class StudioHealthCheck {
     request(this.getRequestUrl(), function(error: any, response: any, body: any) {
       if (error || response.statusCode !== 200) {
         myself.logger.error('Connexion with Studio lost. Shutdown incoming');
+        if(error){
+          myself.logger.error(error);
+        }
         process.exit(1);
       }
     });

--- a/src/server/starter.ts
+++ b/src/server/starter.ts
@@ -23,6 +23,9 @@ import { BdrServer } from './BdrServer';
 import { ConfigurationManager } from './ConfigurationManager';
 import { BdrLogger } from '../logger/BdrLogger';
 
+// Configure no proxy setting
+process.env["NO_PROXY"]="127.0.0.1,localhost";
+
 // Handle server parameters
 let config: Configuration = new ConfigurationManager(process.argv).getConfig();
 


### PR DESCRIPTION
When behind a proxy the node server was denied to request the studio health check endpoint leading to premature shutdown.
Specifying the `NO_PROXY` env variable for the localhost fixes the issue. (Tested on the client site)