### PR TITLE
chore(groovy): Replace used groovy after split

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
 						<dependencies>
 							<dependency>
 								<groupId>org.codehaus.groovy</groupId>
-								<artifactId>groovy-all</artifactId>
+								<artifactId>groovy</artifactId>
 								<version>3.0.8</version>
 							</dependency>
 							<dependency>


### PR DESCRIPTION
covers no tickets

Explanation:
After 3.0.0, groovy-all got split into multiple libs, now you need to import groovy to import all instead of groovy-all