### PR TITLE
fix(groovy-all): Use pom instead jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
 								<groupId>org.codehaus.groovy</groupId>
 								<artifactId>groovy-all</artifactId>
 								<version>3.0.8</version>
+                                <type>pom</type>
 							</dependency>
 							<dependency>
 								<groupId>com.github.jknack</groupId>


### PR DESCRIPTION
* Since 3.x version of groovy-all, only pom is avaible instead of .jar

Covers [UID-657](https://bonitasoft.atlassian.net/browse/UID-657)